### PR TITLE
Fix : Build failure and unnecessary warnings

### DIFF
--- a/lex.h
+++ b/lex.h
@@ -23,7 +23,7 @@ public:
 };
 
 extern std::vector<char> source_code;
-extern size_t curr_pos;
+extern std::size_t curr_pos;
 extern char cache;
 
 #endif /* LEX_H */

--- a/main.cpp
+++ b/main.cpp
@@ -32,7 +32,7 @@ inline std::vector<char> read_vector_from_disk(std::string file_path)
 	}
 }
 
-char *tok_str[] = { "+", "-" , "*" , "/" , "int literal" , "float literal" , "unknown token"};
+const char *tok_str[] = { "+", "-" , "*" , "/" , "int literal" , "float literal" , "unknown token"};
 
 static inline void scan_file()
 {


### PR DESCRIPTION
I see build failure because of size_t is not defined in scope.
In main.cpp it seems you are including iostream and fstream, reason being it works.
But in lex.h won't work. Either can include cstddef or can use `std::size_t`.

For other build warnings, i followed this link : https://stackoverflow.com/questions/42074199/c-forbids-converting-a-string-constant-to-char-alphabets-to-morse-conve